### PR TITLE
fixed splitting string at 256 characters

### DIFF
--- a/assets_from_spf.py
+++ b/assets_from_spf.py
@@ -33,7 +33,8 @@ def get_spf_record(domain):
         logger.info("[+] Couldn't resolve the domain {}".format(domain))
         sys.exit(1)
     for rdata in answers:
-        for record in rdata.strings:
+        fixedRecords = [''.join(rdata.strings)]
+        for record in fixedRecords:
             if 'spf1' in record:
                 spf_record=record
     if 'spf_record' in locals():


### PR DESCRIPTION
In the original script, `rdata.strings` was splitting the entire record every 256 characters. Therefore, sites with long SPF records were not getting complete results, and in some cases crashing the script. For example. `ups.com`. The quickest way to get around this is to join the entire list.